### PR TITLE
eastwood exclude-linters

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -25,7 +25,7 @@
 (deftask test-eastwood []
   (set-env! :source-paths #{"src" "test"})
   (comp
-    (check/with-eastwood)))
+    (check/with-eastwood :options {:exclude-linters [:unused-ret-vals]})))
 
 (deftask test-bikeshed []
   (set-env! :source-paths #{"src" "test"})

--- a/src/tolitius/boot_check.clj
+++ b/src/tolitius/boot_check.clj
@@ -65,7 +65,7 @@
   [t throw-on-errors bool "throw an exception if the check does not pass"]
   (let [pod-pool (make-pod-pool (concat pod-deps eastwood-deps) bootstrap)]
     (core/with-pre-wrap fileset
-      (with-throw #(eastwood/check pod-pool fileset)         ;; TODO with args
+      (with-throw #(eastwood/check pod-pool fileset [:unused-ret-vals])         ;; TODO with args
                   "eastwood checks fail"
                   throw-on-errors)
       fileset)))

--- a/src/tolitius/boot_check.clj
+++ b/src/tolitius/boot_check.clj
@@ -62,10 +62,11 @@
 
   At the moment it takes no arguments, but behold..! it will. (linters, namespaces, etc.)"
   ;; [f files FILE #{sym} "the set of files to check."]      ;; TODO: convert these to "tmp-dir/file"
-  [t throw-on-errors bool "throw an exception if the check does not pass"]
+  [o options OPTIONS edn "eastwood options EDN map"
+   t throw-on-errors bool "throw an exception if the check does not pass"]
   (let [pod-pool (make-pod-pool (concat pod-deps eastwood-deps) bootstrap)]
     (core/with-pre-wrap fileset
-      (with-throw #(eastwood/check pod-pool fileset [:unused-ret-vals])         ;; TODO with args
+      (with-throw #(eastwood/check pod-pool fileset options)
                   "eastwood checks fail"
                   throw-on-errors)
       fileset)))

--- a/src/tolitius/checker/eastwood.clj
+++ b/src/tolitius/checker/eastwood.clj
@@ -5,7 +5,7 @@
 (def eastwood-deps
   '[[jonase/eastwood "0.2.4" :exclusions [org.clojure/clojure]]])
 
-(defn check [pod-pool fileset & args]
+(defn check [pod-pool fileset exclude-linters & args]
   (let [worker-pod (pod-pool :refresh)]
     (pod/with-eval-in worker-pod
       (require '[eastwood.lint :as eastwood])
@@ -13,6 +13,7 @@
       (let [sources# #{~@(tmp-dir-paths fileset)}
             _ (boot.util/dbug (str "eastwood is about to look at: -- " sources# " --"))
             {:keys [some-warnings] :as checks} (eastwood/eastwood {:source-paths sources#
+                                                                   :exclude-linters exclude-linters
                                                                    ;; :debug #{:ns}
                                                                    })]
         (if some-warnings

--- a/src/tolitius/checker/eastwood.clj
+++ b/src/tolitius/checker/eastwood.clj
@@ -5,8 +5,9 @@
 (def eastwood-deps
   '[[jonase/eastwood "0.2.4" :exclusions [org.clojure/clojure]]])
 
-(defn check [pod-pool fileset exclude-linters & args]
-  (let [worker-pod (pod-pool :refresh)]
+(defn check [pod-pool fileset options & args]
+  (let [worker-pod (pod-pool :refresh)
+        exclude-linters (:exclude-linters options)]
     (pod/with-eval-in worker-pod
       (require '[eastwood.lint :as eastwood])
       ;; ~(boot.core/load-data-readers!)

--- a/src/tolitius/checker/eastwood.clj
+++ b/src/tolitius/checker/eastwood.clj
@@ -13,7 +13,7 @@
       (let [sources# #{~@(tmp-dir-paths fileset)}
             _ (boot.util/dbug (str "eastwood is about to look at: -- " sources# " --"))
             {:keys [some-warnings] :as checks} (eastwood/eastwood {:source-paths sources#
-                                                                   :exclude-linters exclude-linters
+                                                                   :exclude-linters ~exclude-linters
                                                                    ;; :debug #{:ns}
                                                                    })]
         (if some-warnings


### PR DESCRIPTION
Would like to be able to exclude eastwood linters. Eventually would like to be able to pass all eastwood options, but I'd like to handle that problem later.