### PR TITLE
Updated README.md. By default You need to require additional namespace - tolitius.reporter.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,8 +518,15 @@ All checkers with this option set to true will write found issues into a shared 
 
 After providing source code with a custom report generator a namespace containing that generator must be evaluated.
 
-Here is an example of how to include a checker task into reporting:
+In case when You want to use default html reporting You also need to add following line into your build.boot:
 
+```Clojure
+(require '[tolitius.reporter.html])
+```          
+Above line will evaluate tolitius.reporter.html namespace which currently contains default html report generator implementation.
+Without above line, clojure runtime will not be able to locate multimethod implementation.
+
+Here is an example of how to include a checker task into reporting:
 ```clojure
 (check/with-kibit :options {:gen-report :true})
 ```

--- a/src/tolitius/boot_check.clj
+++ b/src/tolitius/boot_check.clj
@@ -19,7 +19,6 @@
   '[[org.clojure/tools.namespace "0.2.11" :exclusions [org.clojure/clojure]]])
 
 (defn- store-tmp-file [fileset tmpdir content filename]
-  (core/empty-dir! tmpdir)
   (let [content-file (io/file tmpdir filename)]
     (doto content-file
       io/make-parents
@@ -50,6 +49,7 @@
   (store-tmp-file fileset tmpdir report filename))
 
 (defn- do-report [fileset tmpdir issues options]
+  (core/empty-dir! tmpdir)
   (let [reporter         (core/get-env :boot-check-reporter :html)
         report-path      (core/get-env :report-path  "")
         report-file-name (core/get-env :report-file-name default-report-file-name)


### PR DESCRIPTION
@tolitius 
And yet - there was an issue when generating reports (I think it is only on windows machine). I was clearing temp directory every time before adding items into it. While writing reports - it expected warning interim file to be present (in fact it doesn't use this file at this time - but it must be related to specific filesystem management operation on windows - as it expected file with issues to be present while iterating tmpdir before writing final html report file).

@tolitius 
I do not know how You would like to incorporate this fix? is it required to up the version? or You can make it in-place with current version.   